### PR TITLE
Add basic web catalog app

### DIFF
--- a/catalog.js
+++ b/catalog.js
@@ -1,0 +1,21 @@
+(async function() {
+  const container = document.getElementById('categories');
+  if (!container) return;
+  try {
+    const res = await fetch('/api/categories');
+    const categories = await res.json();
+    container.innerHTML = categories.map(cat => `
+      <div class="col-md-6 col-lg-4">
+        <a href="${cat.link}" class="category-card d-block" style="background-image: url(${cat.image})">
+          <div class="category-overlay">
+            <h3 class="h4 fw-bold mb-2">${cat.name}</h3>
+            <p class="mb-0">${cat.count} productos</p>
+          </div>
+        </a>
+      </div>
+    `).join('');
+    document.dispatchEvent(new Event('categoriesLoaded'));
+  } catch (err) {
+    console.error('Error cargando categorias', err);
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -160,66 +160,8 @@
     <!-- Categorías -->
     <section class="py-5">
         <div class="container">
-            <div class="row g-4">
-                <!-- Categoría 1 -->
-                <div class="col-md-6 col-lg-4">
-                    <a href="bisuteria.html" class="category-card d-block" style="background-image: url(img/bisuteria.jpg)">
-                        <div class="category-overlay">
-                            <h3 class="h4 fw-bold mb-2">Bisutería</h3>
-                            <p class="mb-0">120 productos</p>
-                        </div>
-                    </a>
-                </div>
-                
-                <!-- Categoría 2 -->
-                <div class="col-md-6 col-lg-4">
-                    <a href="#" class="category-card d-block" style="background-image: url(img/acrilico.jpeg)">
-                        <div class="category-overlay">
-                            <h3 class="h4 fw-bold mb-2">Maquillaje</h3>
-                            <p class="mb-0">85 productos</p>
-                        </div>
-                    </a>
-                </div>
-                
-                <!-- Categoría 3 -->
-                <div class="col-md-6 col-lg-4">
-                    <a href="#" class="category-card d-block" style="background-image: url(img/acero.jpg)">
-                        <div class="category-overlay">
-                            <h3 class="h4 fw-bold mb-2">Acero</h3>
-                            <p class="mb-0">45 productos</p>
-                        </div>
-                    </a>
-                </div>
-                
-                <!-- Categoría 4 -->
-                <div class="col-md-6 col-lg-4">
-                    <a href="#" class="category-card d-block" style="background-image: url(img/ofertas.jpeg)">
-                        <div class="category-overlay">
-                            <h3 class="h4 fw-bold mb-2">Acrílico</h3>
-                            <p class="mb-0">62 productos</p>
-                        </div>
-                    </a>
-                </div>
-                
-                <!-- Categoría 5 -->
-                <div class="col-md-6 col-lg-4">
-                    <a href="#" class="category-card d-block" style="background-image: url(img/maquillaje.jpg)">
-                        <div class="category-overlay">
-                            <h3 class="h4 fw-bold mb-2">Ofertas</h3>
-                            <p class="mb-0">35 productos</p>
-                        </div>
-                    </a>
-                </div>
-                
-                <!-- Categoría 6 -->
-                <div class="col-md-6 col-lg-4">
-                    <a href="#" class="category-card d-block" style="background-image: url(img/ofertas.jpeg)">
-                        <div class="category-overlay">
-                            <h3 class="h4 fw-bold mb-2">Novedades</h3>
-                            <p class="mb-0">28 productos</p>
-                        </div>
-                    </a>
-                </div>
+            <div id="categories" class="row g-4">
+                <!-- Las categorías se insertarán dinámicamente -->
             </div>
         </div>
     </section>
@@ -295,24 +237,25 @@
 
     <!-- Bootstrap JS (para el menú móvil) -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    
+    <script src="catalog.js"></script>
+
     <!-- Script propio -->
     <script>
-        // Simple animation for category cards
-        document.addEventListener('DOMContentLoaded', function() {
+        function animateCategories() {
             const categories = document.querySelectorAll('.category-card');
-            
             categories.forEach((card, index) => {
                 card.style.opacity = '0';
                 card.style.transform = 'translateY(20px)';
                 card.style.transition = `all 0.3s ease ${index * 0.1}s`;
-                
+
                 setTimeout(() => {
                     card.style.opacity = '1';
                     card.style.transform = 'translateY(0)';
                 }, 100);
             });
-        });
+        }
+
+        document.addEventListener('categoriesLoaded', animateCategories);
     </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fashion-collection-webapp",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/products.json
+++ b/products.json
@@ -1,0 +1,10 @@
+{
+  "categories": [
+    {"name": "Bisutería", "image": "img/bisuteria.jpg", "count": 120, "link": "bisuteria.html"},
+    {"name": "Maquillaje", "image": "img/acrilico.jpeg", "count": 85, "link": "#"},
+    {"name": "Acero", "image": "img/acero.jpg", "count": 45, "link": "#"},
+    {"name": "Acrílico", "image": "img/ofertas.jpeg", "count": 62, "link": "#"},
+    {"name": "Ofertas", "image": "img/maquillaje.jpg", "count": 35, "link": "#"},
+    {"name": "Novedades", "image": "img/ofertas.jpeg", "count": 28, "link": "#"}
+  ]
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(__dirname));
+
+app.get('/api/categories', (req, res) => {
+  fs.readFile(path.join(__dirname, 'products.json'), 'utf8', (err, data) => {
+    if (err) {
+      res.status(500).json({ error: 'Unable to load data' });
+    } else {
+      const info = JSON.parse(data);
+      res.json(info.categories);
+    }
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- convert catalog area of `index.html` to load categories dynamically
- add client-side script `catalog.js` to fetch categories
- provide sample category data in `products.json`
- create `server.js` and `package.json` to run an Express server

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6858719dca9c8322bb195086c95339cb